### PR TITLE
WOLO-164 Fix cors integration for preflight requests

### DIFF
--- a/src/main/java/pl/pjwstk/woloappapi/configs/SecurityConfig.java
+++ b/src/main/java/pl/pjwstk/woloappapi/configs/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                     auth.requestMatchers(DELETE, "/districts/**").hasAuthority("DELETE_DISTRICT");
                     auth.requestMatchers(GET, "/events").permitAll();
                     auth.requestMatchers(GET, "/events/**").permitAll();
+                    auth.requestMatchers(OPTIONS,"/events/join").permitAll();
                     auth.requestMatchers( "/events/join").hasAuthority("JOIN_EVENT");
                     auth.requestMatchers("events/refuse").hasAuthority("JOIN_EVENT");
                     auth.requestMatchers("events/add").hasAuthority("CREATE_EVENT");


### PR DESCRIPTION
Added to SecurityConfig.java ability to send fetch OPTIONS without bearer token so that more complicated POST fetches will be treated as normally. 