### PR TITLE
.DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Mac ###
+.DS_Store
+


### PR DESCRIPTION
aby nie brudzić repo niepotrzebnymi domyślnymi plikami systemu MacOS.